### PR TITLE
add abi comap ops

### DIFF
--- a/rustfmt.sh
+++ b/rustfmt.sh
@@ -3,3 +3,4 @@
 rustfmt ./tests/*.rs
 rustfmt ./src/element_interfaces/debug_data.rs
 rustfmt ./src/narm_hypervisor.rs
+rustfmt ./src/comap_abi_decoder.rs

--- a/src/comap_abi_decoder.rs
+++ b/src/comap_abi_decoder.rs
@@ -1,7 +1,14 @@
-// Functions to efficiently decode neutron comap headers
-// General note: Whenever it matters little-endian byte order is used, unless explicitly stated otherwise
+/*
 
-// TODO: Move to neutron-common, will at least be used in neutron-star too down the line
+Functions to efficiently decode neutron comap headers
+
+For docs see https://neutron.earlgrey.tech/spec/neutronabi
+
+General note: Whenever it matters little-endian byte order is used, unless explicitly stated otherwise
+
+TODO: Move to neutron-common, will at least be used in neutron-star too down the line
+
+*/
 
 // A long list of constants isn't pretty, the important thing is that it gets inlined by the compiler.
 const HEADER_SIZE_MASK: u8 = 0b11000000;

--- a/src/comap_abi_decoder.rs
+++ b/src/comap_abi_decoder.rs
@@ -11,11 +11,11 @@ TODO: Move to neutron-common, will at least be used in neutron-star too down the
 */
 
 // A long list of constants isn't pretty, the important thing is that it gets inlined by the compiler.
-const HEADER_SIZE_MASK: u8 = 0b11000000;
-const HEADER_SIZE_1: u8 = 0b00000000;
-const HEADER_SIZE_2: u8 = 0b01000000;
-const HEADER_SIZE_4: u8 = 0b10000000;
-const HEADER_SIZE_RESERVED: u8 = 0b11000000;
+pub const HEADER_SIZE_MASK: u8 = 0b11000000;
+pub const HEADER_SIZE_1: u8 = 0b00000000;
+pub const HEADER_SIZE_2: u8 = 0b01000000;
+pub const HEADER_SIZE_4: u8 = 0b10000000;
+pub const HEADER_SIZE_RESERVED: u8 = 0b11000000;
 
 // These following will be used in the full decoder
 

--- a/src/comap_abi_decoder.rs
+++ b/src/comap_abi_decoder.rs
@@ -1,0 +1,218 @@
+// Functions to efficiently decode neutron comap headers
+// General note: Whenever it matters little-endian byte order is used, unless explicitly stated otherwise
+
+// TODO: Move to neutron-common, will at least be used in neutron-star too down the line
+
+// A long list of constants isn't pretty, the important thing is that it gets inlined by the compiler.
+const HEADER_SIZE_MASK: u8 = 0b11000000;
+const HEADER_SIZE_1: u8 = 0b00000000;
+const HEADER_SIZE_2: u8 = 0b01000000;
+const HEADER_SIZE_4: u8 = 0b10000000;
+const HEADER_SIZE_RESERVED: u8 = 0b11000000;
+
+// These following will be used in the full decoder
+
+/*
+const TYPE_CATEGORY_MASK: u8    = 0b00100000;
+const TYPE_CATEGORY_NUMERIC: u8 = 0b00000000;
+const TYPE_CATEGORY_SPECIAL: u8 = 0b00100000;
+
+const HEX_OR_BIGNUM_MASK: u8    = 0b00010000;
+const HEX_OR_BIGNUM_FALSE: u8   = 0b00000000;
+const HEX_OR_BIGNUM_TRUE: u8    = 0b00010000;
+
+const IS_ARRAY_MASK: u8         = 0b00001000;
+const IS_ARRAY_FALSE: u8        = 0b00000000;
+const IS_ARRAY_TRUE: u8         = 0b00001000;
+
+const NUMERIC_TYPE_MASK: u8     = 0b00000111;
+const NUMERIC_TYPE_U8: u8       = 0b00000000;
+const NUMERIC_TYPE_I8: u8       = 0b00000100;
+const NUMERIC_TYPE_U16: u8      = 0b00000010;
+const NUMERIC_TYPE_I16: u8      = 0b00000110;
+const NUMERIC_TYPE_U32: u8      = 0b00000001;
+const NUMERIC_TYPE_I32: u8      = 0b00000101;
+const NUMERIC_TYPE_U64: u8      = 0b00000011;
+const NUMERIC_TYPE_I64: u8      = 0b00000111;
+
+#[derive(PartialEq)]
+pub enum ComapDataType {
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    U64,
+    I64,
+    UNDEFINED,
+}
+
+*/
+
+// Returns: (header_size: usize, header_u32: u32)
+pub fn comap_abi_header_to_u32(data: &[u8]) -> (usize, u32) {
+    let mut header_size: usize = 0;
+    let mut header_u32: u32 = 0;
+
+    let first_byte = data[0];
+
+    // Look at bit 8 and 7 of first byte to determine header size
+    match first_byte & HEADER_SIZE_MASK {
+        HEADER_SIZE_1 => {
+            header_size = 1;
+            header_u32 = u32::from_le_bytes([first_byte, 0_u8, 0_u8, 0_u8]);
+        }
+        HEADER_SIZE_2 => {
+            header_size = 2;
+            header_u32 = u32::from_le_bytes([first_byte, data[1], 0_u8, 0_u8]);
+        }
+        HEADER_SIZE_4 => {
+            header_size = 4;
+            header_u32 = u32::from_le_bytes([first_byte, data[1], data[2], data[3]]);
+        }
+        HEADER_SIZE_RESERVED => panic!("Reserved codata size type isn't implemented yet!"),
+        _ => println!(
+            "Failed to match comap header data to a valid pattern (This should never happen)"
+        ),
+    }
+
+    (header_size, header_u32)
+}
+
+// Note: All 4 bytes from the provided u32 are always returned for simplicity. No need to explicitly clear the "extra" bytes,
+// since the caller can use header_size to extract only the actual header bytes
+// Returns: (header_size: usize, header_bytes: [u8;4])
+pub fn comap_abi_header_from_u32(header_u32: u32) -> (usize, [u8; 4]) {
+    let mut header_size: usize = 0;
+
+    let header_bytes = header_u32.to_le_bytes();
+    let first_byte = header_bytes[0];
+
+    // Look at bit 8 and 7 of first byte to determine header size
+    match first_byte & HEADER_SIZE_MASK {
+        HEADER_SIZE_1 => {
+            header_size = 1;
+        }
+        HEADER_SIZE_2 => {
+            header_size = 2;
+        }
+        HEADER_SIZE_4 => {
+            header_size = 4;
+        }
+        HEADER_SIZE_RESERVED => panic!("Reserved codata size type isn't implemented yet!"),
+        _ => println!(
+            "Failed to match comap header data to a valid pattern (This should never happen)"
+        ),
+    }
+
+    (header_size, header_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These are just here to make the assignment patterns easier to compare
+    const EMPTY_BYTE: u8 = 0x00;
+    const EMPTY_U32_2: u32 = 0x0000_0000;
+    const EMPTY_U32_3: u32 = 0x0000_0000;
+    const EMPTY_U32_4: u32 = 0x0000_0000;
+
+    const HEADER_BYTE: u8 = 0xAA;
+    const HEADER_U32_2: u32 = 0x0000_AA00;
+    const HEADER_U32_3: u32 = 0x00AA_0000;
+    const HEADER_U32_4: u32 = 0xAA00_0000;
+
+    const VALUE_BYTE: u8 = 0xDD;
+
+    // Basic tests for comap_abi_header_to_u32
+    #[test]
+    fn test_get_header_u32_1() {
+        let data: Vec<u8> = vec![HEADER_SIZE_1, VALUE_BYTE];
+        let (header_size, header_u32) = comap_abi_header_to_u32(&data);
+        assert_eq!(header_size, 1, "abi return value 'header_size' was wrong");
+        let expected_header = (HEADER_SIZE_1 as u32) + EMPTY_U32_2 + EMPTY_U32_3 + EMPTY_U32_4;
+        assert_eq!(
+            header_u32, expected_header,
+            "abi return value 'header_u32' was wrong"
+        );
+    }
+    #[test]
+    fn test_get_header_u32_2() {
+        let data: Vec<u8> = vec![HEADER_SIZE_2, HEADER_BYTE, VALUE_BYTE];
+        let (header_size, header_u32) = comap_abi_header_to_u32(&data);
+        assert_eq!(header_size, 2, "abi return value 'header_size' was wrong");
+        let expected_header = (HEADER_SIZE_2 as u32) + HEADER_U32_2 + EMPTY_U32_3 + EMPTY_U32_4;
+        assert_eq!(
+            header_u32, expected_header,
+            "abi return value 'header_u32' was wrong"
+        );
+    }
+    #[test]
+    fn test_get_header_u32_4() {
+        let data: Vec<u8> = vec![
+            HEADER_SIZE_4,
+            HEADER_BYTE,
+            HEADER_BYTE,
+            HEADER_BYTE,
+            VALUE_BYTE,
+        ];
+        let (header_size, header_u32) = comap_abi_header_to_u32(&data);
+        assert_eq!(header_size, 4, "abi return value 'header_size' was wrong");
+        let expected_header = (HEADER_SIZE_4 as u32) + HEADER_U32_2 + HEADER_U32_3 + HEADER_U32_4;
+        assert_eq!(
+            header_u32, expected_header,
+            "abi return value 'header_u32' was wrong"
+        );
+    }
+    #[test]
+    #[should_panic]
+    // The "reserved" data size is currently not implemented and should panic
+    fn negtest_get_header_u32_reserved() {
+        let data: Vec<u8> = vec![HEADER_SIZE_RESERVED, VALUE_BYTE];
+        let (_header_size, _header_u32) = comap_abi_header_to_u32(&data);
+    }
+
+    // Basic tests for comap_abi_header_from_u32
+    #[test]
+    fn test_get_header_bytes_1() {
+        let data: u32 = (HEADER_SIZE_1 as u32) + EMPTY_U32_2 + EMPTY_U32_3 + EMPTY_U32_4;
+        let (header_size, header_bytes) = comap_abi_header_from_u32(data);
+        assert_eq!(header_size, 1, "\nReturn value 'header_size' was wrong");
+        assert_eq!(
+            header_bytes,
+            [HEADER_SIZE_1, EMPTY_BYTE, EMPTY_BYTE, EMPTY_BYTE],
+            "\nReturn value 'header_bytes' was wrong"
+        );
+    }
+    #[test]
+    fn test_get_header_bytes_2() {
+        let data: u32 = (HEADER_SIZE_2 as u32) + HEADER_U32_2 + EMPTY_U32_3 + EMPTY_U32_4;
+        let (header_size, header_bytes) = comap_abi_header_from_u32(data);
+        assert_eq!(header_size, 2, "\nReturn value 'header_size' was wrong");
+        assert_eq!(
+            header_bytes,
+            [HEADER_SIZE_2, HEADER_BYTE, EMPTY_BYTE, EMPTY_BYTE],
+            "\nReturn value 'header_bytes' was wrong"
+        );
+    }
+    #[test]
+    fn test_get_header_bytes_4() {
+        let data: u32 = (HEADER_SIZE_4 as u32) + HEADER_U32_2 + HEADER_U32_3 + HEADER_U32_4;
+        let (header_size, header_bytes) = comap_abi_header_from_u32(data);
+        assert_eq!(header_size, 4, "\nReturn value 'header_size' was wrong");
+        assert_eq!(
+            header_bytes,
+            [HEADER_SIZE_4, HEADER_BYTE, HEADER_BYTE, HEADER_BYTE],
+            "\nReturn value 'header_bytes' was wrong"
+        );
+    }
+    #[test]
+    #[should_panic]
+    // The "reserved" data size is currently not implemented and should panic
+    fn negtest_get_header_bytes_4() {
+        let data: u32 = HEADER_SIZE_RESERVED as u32;
+        let (_header_size, _header_bytes) = comap_abi_header_from_u32(data);
+    }
+}

--- a/src/element_interfaces/debug_data.rs
+++ b/src/element_interfaces/debug_data.rs
@@ -396,11 +396,11 @@ impl DebugCoMap {
         }
     }
 
-    // Check contract output stack against expected state
+    // Check contract output map against expected state
     pub fn assert_eq(&mut self, codata: &mut CoData) {
         println!("[DebugCoData] Asserting expected CoMap values against actual output CoMap...");
         for key in self.map.keys() {
-            let key_str = str::from_utf8(key).unwrap();
+            let key_str = String::from_utf8_lossy(key);
 
             let expected_data = self.map.get(key).unwrap();
             let actual_data = match codata.peek_input_key(key) {
@@ -410,8 +410,8 @@ impl DebugCoMap {
                     key_str
                 ),
             };
-            let expected_data_str = str::from_utf8(expected_data).unwrap();
-            let actual_data_str = str::from_utf8(&actual_data).unwrap();
+            let expected_data_str = String::from_utf8_lossy(expected_data);
+            let actual_data_str = String::from_utf8_lossy(&actual_data);
 
             assert_eq!(
                 expected_data, &actual_data,

--- a/src/element_interfaces/debug_data.rs
+++ b/src/element_interfaces/debug_data.rs
@@ -604,4 +604,6 @@ mod tests {
         let result = stack.to_u8(bytes);
         assert_eq!(result, 0x11 as u8);
     }
+    
+    // TODO: Tests for debug comap functionality
 }

--- a/src/element_interfaces/debug_data.rs
+++ b/src/element_interfaces/debug_data.rs
@@ -1,5 +1,6 @@
 use crate::callsystem::*;
 use crate::codata::*;
+use crate::comap_abi_decoder::*;
 use crate::neutronerror::NeutronError::*;
 use crate::neutronerror::*;
 use core::mem::transmute;
@@ -382,6 +383,20 @@ impl DebugCoMap {
         }
         self.map.insert(key.to_vec(), value.to_vec());
         Ok(())
+    }
+
+    // For u32 ABI header
+    pub fn push_key_abi(
+        &mut self,
+        key: &[u8],
+        value: &[u8],
+        abi_data: u32,
+    ) -> Result<(), NeutronError> {
+        let (header_size, header_bytes) = comap_abi_header_from_u32(abi_data);
+        let mut full_value = vec![];
+        full_value.extend_from_slice(&header_bytes[0..header_size]);
+        full_value.extend_from_slice(&value);
+        self.push_key(key, &full_value)
     }
 
     pub fn peek_key(&mut self, key: &[u8]) -> Result<Vec<u8>, NeutronError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod callsystem;
 pub mod vmmanager;
 pub mod manager;
 pub mod harness;
+pub mod comap_abi_decoder;
 pub extern crate neutron_common as addressing;
 
 extern crate num;

--- a/src/narm_hypervisor.rs
+++ b/src/narm_hypervisor.rs
@@ -121,6 +121,7 @@ impl NarmHypervisor {
                     };
 
                     // Get ABI length and byte representation, then assemble final value
+                    // TODO: Investigate more efficient option for slice concaternation
                     let (header_size, header_bytes) = comap_abi_header_from_u32(abi_data);
                     let mut value = vec![];
                     value.extend_from_slice(&header_bytes[0..header_size]);

--- a/src/narm_hypervisor.rs
+++ b/src/narm_hypervisor.rs
@@ -173,23 +173,17 @@ impl NarmHypervisor {
                         }
                     };
 
-                    let mut raw_value = match codata.peek_input_key(&key) {
+                    let raw_value = match codata.peek_input_key(&key) {
                         Ok(d) => d,
                         Err(e) => {
                             return Ok(HypervisorState::Error(e));
                         }
                     };
 
-                    // Discard bytes before specified start position
-                    // TODO: Find solution that doesn't reallocate? Not super important though since read from start should be by far most common in calls
-                    if begin > 0 {
-                        raw_value = raw_value.split_off(begin);
-                    }
+                    // We will from begin read either max_length bytes or until end of data, whichever comes first
+                    let read_to = cmp::min(begin + max_length, raw_value.len());
 
-                    // Truncate value if larger than provided max size
-                    raw_value.truncate(max_length);
-
-                    match codata.push_output_stack(&raw_value) {
+                    match codata.push_output_stack(&raw_value[begin..read_to]) {
                         Ok(_) => {}
                         Err(e) => {
                             return Ok(HypervisorState::Error(e));
@@ -210,23 +204,17 @@ impl NarmHypervisor {
                         }
                     };
 
-                    let mut raw_value = match codata.peek_result_key(&key) {
+                    let raw_value = match codata.peek_result_key(&key) {
                         Ok(d) => d,
                         Err(e) => {
                             return Ok(HypervisorState::Error(e));
                         }
                     };
 
-                    // Discard bytes before specified start position
-                    // TODO: Find solution that doesn't reallocate? Not super important though since read from start should be by far most common in calls
-                    if begin > 0 {
-                        raw_value = raw_value.split_off(begin);
-                    }
+                    // We will from begin read either max_length bytes or until end of data, whichever comes first
+                    let read_to = cmp::min(begin + max_length, raw_value.len());
 
-                    // Truncate the value if above provided max size
-                    raw_value.truncate(max_length);
-
-                    match codata.push_output_stack(&raw_value) {
+                    match codata.push_output_stack(&raw_value[begin..read_to]) {
                         Ok(_) => {}
                         Err(e) => {
                             return Ok(HypervisorState::Error(e));

--- a/tests/README.txt
+++ b/tests/README.txt
@@ -1,1 +1,3 @@
 Don't forget to run build.sh to compile the smart contracts used in testing! 
+
+Note that since parts of contract repos aren't tracked by git parts can be left when switching branches, and this can cause contract build errors. These are harmless, but can be fixed by simply deleting the folder of the offending contract (That doesn't actually exist in your current branch). 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 // Every subfolder with tests need to be defined as modules here, otherwise they won't be executed
 mod test_comap;
+mod test_comap_abi;
 mod test_debugdata;
 mod test_smoke;
 mod example_new_element;

--- a/tests/test_comap_abi/contract_map_to_stack/.cargo/config
+++ b/tests/test_comap_abi/contract_map_to_stack/.cargo/config
@@ -1,0 +1,36 @@
+[target.thumbv6m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+# runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+rustflags = [
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  # "-C", "link-arg=--nmagic",
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+  "-C", "relocation-model=static",
+  "-C", "target-feature=+crt-static"
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  # "-C", "linker=arm-none-eabi-ld",
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
+]
+[build]
+# Pick ONE of these compilation targets
+target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"        # Cortex-M3
+# target = "thumbv7em-none-eabi"       # Cortex-M4 and Cortex-M7 (no FPU)
+# target = "thumbv7em-none-eabihf"     # Cortex-M4F and Cortex-M7F (with FPU)
+# target = "thumbv8m.base-none-eabi"   # Cortex-M23
+# target = "thumbv8m.main-none-eabi"   # Cortex-M33 (no FPU)
+# target = "thumbv8m.main-none-eabihf" # Cortex-M33 (with FPU)

--- a/tests/test_comap_abi/contract_map_to_stack/Cargo.toml
+++ b/tests/test_comap_abi/contract_map_to_stack/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "contract-binary"
+version = "0.1.0"
+authors = ["earlz <earlz@earlz.net>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "contract-binary"
+test = false
+bench = false
+
+[dependencies]
+neutron-star-rt = { path = "../../../../neutron-star-rt" }
+neutron-star = { path = "../../../../neutron-star" }
+panic-halt = "0.2.0"

--- a/tests/test_comap_abi/contract_map_to_stack/src/main.rs
+++ b/tests/test_comap_abi/contract_map_to_stack/src/main.rs
@@ -1,0 +1,34 @@
+//! Directly plug a `main` symbol instead of using `#[entry]`
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use neutron_star_rt::*;
+//use neutron_star::*;
+extern crate panic_halt;
+
+// We need to provide a fixed starting point and size limit for data peeked from comap
+const DATA_READ_START: usize = 0;
+const MAX_RESULT_SIZE: usize = 25;
+
+const DEBUG_DATA_FEATURE: u32 = 0x4000_0001;
+
+// This contract takes a resulut comap entry (found by key popped from input costack) and pushes it to output costack
+#[no_mangle]
+pub unsafe extern "C" fn main() -> ! {
+    __system_call(DEBUG_DATA_FEATURE, 3); // DebugDataFunctions::PushResultMap
+    
+    // Load key into costack and use it as parameter for comap lookup
+    __system_call(DEBUG_DATA_FEATURE, 1); // DebugDataFunctions::PushInputStack
+    let abi_data = __peek_result_comap(DATA_READ_START, MAX_RESULT_SIZE);
+    
+    // Push ABI data to stack 
+    let abi_data_buf = u32::to_ne_bytes(abi_data);
+    __push_costack(abi_data_buf.as_ptr(), 4);
+    
+    // Assert the result of the comap lookup
+    __system_call(DEBUG_DATA_FEATURE, 2); // DebugDataFunctions::AssertOutputStack
+    
+    __exit(5);
+}

--- a/tests/test_comap_abi/contract_stack_to_map/.cargo/config
+++ b/tests/test_comap_abi/contract_stack_to_map/.cargo/config
@@ -1,0 +1,36 @@
+[target.thumbv6m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+# runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+rustflags = [
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  # "-C", "link-arg=--nmagic",
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+  "-C", "relocation-model=static",
+  "-C", "target-feature=+crt-static"
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  # "-C", "linker=arm-none-eabi-ld",
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
+]
+[build]
+# Pick ONE of these compilation targets
+target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"        # Cortex-M3
+# target = "thumbv7em-none-eabi"       # Cortex-M4 and Cortex-M7 (no FPU)
+# target = "thumbv7em-none-eabihf"     # Cortex-M4F and Cortex-M7F (with FPU)
+# target = "thumbv8m.base-none-eabi"   # Cortex-M23
+# target = "thumbv8m.main-none-eabi"   # Cortex-M33 (no FPU)
+# target = "thumbv8m.main-none-eabihf" # Cortex-M33 (with FPU)

--- a/tests/test_comap_abi/contract_stack_to_map/Cargo.toml
+++ b/tests/test_comap_abi/contract_stack_to_map/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "contract-binary"
+version = "0.1.0"
+authors = ["earlz <earlz@earlz.net>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "contract-binary"
+test = false
+bench = false
+
+[dependencies]
+neutron-star-rt = { path = "../../../../neutron-star-rt" }
+neutron-star = { path = "../../../../neutron-star" }
+panic-halt = "0.2.0"

--- a/tests/test_comap_abi/contract_stack_to_map/src/main.rs
+++ b/tests/test_comap_abi/contract_stack_to_map/src/main.rs
@@ -1,0 +1,30 @@
+//! Directly plug a `main` symbol instead of using `#[entry]`
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use neutron_star_rt::*;
+//use neutron_star::*;
+extern crate panic_halt;
+
+const DEBUG_DATA_FEATURE: u32 = 0x4000_0001;
+
+// This contract takes a key-value pair and an abi data on the input costack and pushes it to the output comap
+#[no_mangle]
+pub unsafe extern "C" fn main() -> ! {
+    // Push provided input stack to codata input stack
+    __system_call(DEBUG_DATA_FEATURE, 1); // DebugDataFunctions::PushInputStack
+    
+    // Pop ABI data bytes and cast to u32
+    let mut abi_data_buf: [u8; 4] = [0; 4]; 
+    let _ = __pop_costack(abi_data_buf.as_mut_ptr(), 4);
+    let abi_data = u32::from_ne_bytes(abi_data_buf); 
+    
+    // Push key/value from costack to comap
+    __push_comap(abi_data);
+    
+    __system_call(DEBUG_DATA_FEATURE, 4); // DebugDataFunctions::AssertOutputMap
+    
+    __exit(5);
+}

--- a/tests/test_comap_abi/contract_subsetting/.cargo/config
+++ b/tests/test_comap_abi/contract_subsetting/.cargo/config
@@ -1,0 +1,36 @@
+[target.thumbv6m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+# runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+rustflags = [
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  # "-C", "link-arg=--nmagic",
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+  "-C", "relocation-model=static",
+  "-C", "target-feature=+crt-static"
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  # "-C", "linker=arm-none-eabi-ld",
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
+]
+[build]
+# Pick ONE of these compilation targets
+target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"        # Cortex-M3
+# target = "thumbv7em-none-eabi"       # Cortex-M4 and Cortex-M7 (no FPU)
+# target = "thumbv7em-none-eabihf"     # Cortex-M4F and Cortex-M7F (with FPU)
+# target = "thumbv8m.base-none-eabi"   # Cortex-M23
+# target = "thumbv8m.main-none-eabi"   # Cortex-M33 (no FPU)
+# target = "thumbv8m.main-none-eabihf" # Cortex-M33 (with FPU)

--- a/tests/test_comap_abi/contract_subsetting/Cargo.toml
+++ b/tests/test_comap_abi/contract_subsetting/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "contract-binary"
+version = "0.1.0"
+authors = ["earlz <earlz@earlz.net>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "contract-binary"
+test = false
+bench = false
+
+[dependencies]
+neutron-star-rt = { path = "../../../../neutron-star-rt" }
+neutron-star = { path = "../../../../neutron-star" }
+panic-halt = "0.2.0"

--- a/tests/test_comap_abi/contract_subsetting/src/main.rs
+++ b/tests/test_comap_abi/contract_subsetting/src/main.rs
@@ -1,0 +1,37 @@
+//! Directly plug a `main` symbol instead of using `#[entry]`
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use neutron_star_rt::*;
+//use neutron_star::*;
+extern crate panic_halt;
+
+// 3 subsets of 15 bytes each
+const SUBSET_COUNT: usize = 3;
+const SUBSET_SIZE: usize = 15;
+
+const DEBUG_DATA_FEATURE: u32 = 0x4000_0001;
+
+// This contract uses a key (Pushed several times) on costack to repetedly peek subsets of a codata entry (to the costack)
+#[no_mangle]
+pub unsafe extern "C" fn main() -> ! {
+    __system_call(DEBUG_DATA_FEATURE, 3); // DebugDataFunctions::PushResultMap
+    
+    // Push keys to costack
+    __system_call(DEBUG_DATA_FEATURE, 1); // DebugDataFunctions::PushInputStack
+    
+    // Peek all the subsets of the comap value to the costack
+    for i in 0..SUBSET_COUNT {
+        let abi_data = __peek_result_comap(SUBSET_SIZE * i, SUBSET_SIZE);
+        // Push ABI data to stack 
+        let abi_data_buf = u32::to_ne_bytes(abi_data);
+        __push_costack(abi_data_buf.as_ptr(), 4);
+    }
+
+    // Assert the result of the comap subset peeking
+    __system_call(DEBUG_DATA_FEATURE, 2); // DebugDataFunctions::AssertOutputStack
+    
+    __exit(5);
+}

--- a/tests/test_comap_abi/mod.rs
+++ b/tests/test_comap_abi/mod.rs
@@ -1,2 +1,4 @@
 // Every test file needs to be added here
+mod test_map_to_stack;
 mod test_stack_to_map;
+mod test_subsetting;

--- a/tests/test_comap_abi/mod.rs
+++ b/tests/test_comap_abi/mod.rs
@@ -1,0 +1,2 @@
+// Every test file needs to be added here
+mod test_stack_to_map;

--- a/tests/test_comap_abi/test_map_to_stack.rs
+++ b/tests/test_comap_abi/test_map_to_stack.rs
@@ -1,0 +1,212 @@
+use neutron_host::comap_abi_decoder::*;
+use neutron_host::element_interfaces::debug_data::*;
+use neutron_host::harness::*;
+use neutron_host::interface::*;
+
+const DIR_NAME: &'static str = "test_comap_abi";
+
+const CONTRACT_DIR_NAME: &'static str = "contract_map_to_stack";
+
+#[test]
+fn test_comap_peek_header_size_1() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    stack.push_str(key);
+    expected_stack.push_str(raw_value, "comap_value");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    map.push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+fn test_comap_peek_header_size_2() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_2 as u32 + 0x0000_4200;
+
+    stack.push_str(key);
+    expected_stack.push_str(raw_value, "comap_value");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    map.push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+fn test_comap_peek_header_size_4() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_4 as u32 + 0x4242_4200;
+
+    stack.push_str(key);
+    expected_stack.push_str(raw_value, "comap_value");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    map.push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_peek_header_wrong_key() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let wrong_key = "this is the WRONG key";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    stack.push_str(key);
+    expected_stack.push_str(raw_value, "comap_value");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    map.push_key_abi(wrong_key.as_bytes(), raw_value.as_bytes(), abi_data)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_peek_header_wrong_value() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let wrong_raw_value = "this is the WRONG value";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    stack.push_str(key);
+    expected_stack.push_str(raw_value, "comap_value");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    map.push_key_abi(key.as_bytes(), wrong_raw_value.as_bytes(), abi_data)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_peek_header_wrong_size() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_1 as u32;
+    let wrong_abi_data = HEADER_SIZE_2 as u32 + 0x0000_4200;
+
+    stack.push_str(key);
+    expected_stack.push_str(raw_value, "comap_value");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    map.push_key_abi(key.as_bytes(), raw_value.as_bytes(), wrong_abi_data)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}

--- a/tests/test_comap_abi/test_stack_to_map.rs
+++ b/tests/test_comap_abi/test_stack_to_map.rs
@@ -19,12 +19,8 @@ fn test_comap_push_header_size_1() {
     stack.push_str(raw_value);
     stack.push_u32(abi_data);
 
-    let mut expected_value = vec![];
-    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
-    expected_value.extend_from_slice(&raw_value.as_bytes());
-
     expected_map
-        .push_key(key.as_bytes(), &expected_value)
+        .push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
         .unwrap();
 
     let mut harness = TestHarness::default();
@@ -55,12 +51,8 @@ fn test_comap_push_header_size_2() {
     stack.push_str(raw_value);
     stack.push_u32(abi_data);
 
-    let mut expected_value = vec![];
-    expected_value.extend_from_slice(&[HEADER_SIZE_2, 0x42 as u8]);
-    expected_value.extend_from_slice(&raw_value.as_bytes());
-
     expected_map
-        .push_key(key.as_bytes(), &expected_value)
+        .push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
         .unwrap();
 
     let mut harness = TestHarness::default();
@@ -91,12 +83,8 @@ fn test_comap_push_header_size_4() {
     stack.push_str(raw_value);
     stack.push_u32(abi_data);
 
-    let mut expected_value = vec![];
-    expected_value.extend_from_slice(&[HEADER_SIZE_4, 0x42 as u8, 0x37 as u8, 0x13 as u8]);
-    expected_value.extend_from_slice(&raw_value.as_bytes());
-
     expected_map
-        .push_key(key.as_bytes(), &expected_value)
+        .push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
         .unwrap();
 
     let mut harness = TestHarness::default();
@@ -129,12 +117,8 @@ fn negtest_comap_push_header_wrong_key() {
     stack.push_str(raw_value);
     stack.push_u32(abi_data);
 
-    let mut expected_value = vec![];
-    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
-    expected_value.extend_from_slice(&raw_value.as_bytes());
-
     expected_map
-        .push_key(key.as_bytes(), &expected_value)
+        .push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
         .unwrap();
 
     let mut harness = TestHarness::default();
@@ -167,12 +151,8 @@ fn negtest_comap_push_header_wrong_value() {
     stack.push_str(wrong_raw_value);
     stack.push_u32(abi_data);
 
-    let mut expected_value = vec![];
-    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
-    expected_value.extend_from_slice(&raw_value.as_bytes());
-
     expected_map
-        .push_key(key.as_bytes(), &expected_value)
+        .push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
         .unwrap();
 
     let mut harness = TestHarness::default();
@@ -198,18 +178,15 @@ fn negtest_comap_push_header_wrong_size() {
 
     let key = "this is the key";
     let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_1 as u32;
     let wrong_abi_data = HEADER_SIZE_2 as u32;
 
     stack.push_str(key);
     stack.push_str(raw_value);
     stack.push_u32(wrong_abi_data);
 
-    let mut expected_value = vec![];
-    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
-    expected_value.extend_from_slice(&raw_value.as_bytes());
-
     expected_map
-        .push_key(key.as_bytes(), &expected_value)
+        .push_key_abi(key.as_bytes(), raw_value.as_bytes(), abi_data)
         .unwrap();
 
     let mut harness = TestHarness::default();

--- a/tests/test_comap_abi/test_stack_to_map.rs
+++ b/tests/test_comap_abi/test_stack_to_map.rs
@@ -1,0 +1,228 @@
+use neutron_host::comap_abi_decoder::*;
+use neutron_host::element_interfaces::debug_data::*;
+use neutron_host::harness::*;
+use neutron_host::interface::*;
+
+const DIR_NAME: &'static str = "test_comap_abi";
+const CONTRACT_DIR_NAME: &'static str = "contract_stack_to_map";
+
+#[test]
+fn test_comap_push_header_size_1() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    stack.push_str(key);
+    stack.push_str(raw_value);
+    stack.push_u32(abi_data);
+
+    let mut expected_value = vec![];
+    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
+    expected_value.extend_from_slice(&raw_value.as_bytes());
+
+    expected_map
+        .push_key(key.as_bytes(), &expected_value)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_map: expected_map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+fn test_comap_push_header_size_2() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = (HEADER_SIZE_2 as u32) + 0x0000_4200;
+
+    stack.push_str(key);
+    stack.push_str(raw_value);
+    stack.push_u32(abi_data);
+
+    let mut expected_value = vec![];
+    expected_value.extend_from_slice(&[HEADER_SIZE_2, 0x42 as u8]);
+    expected_value.extend_from_slice(&raw_value.as_bytes());
+
+    expected_map
+        .push_key(key.as_bytes(), &expected_value)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_map: expected_map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+fn test_comap_push_header_size_4() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let abi_data = (HEADER_SIZE_4 as u32) + 0x1337_4200;
+
+    stack.push_str(key);
+    stack.push_str(raw_value);
+    stack.push_u32(abi_data);
+
+    let mut expected_value = vec![];
+    expected_value.extend_from_slice(&[HEADER_SIZE_4, 0x42 as u8, 0x37 as u8, 0x13 as u8]);
+    expected_value.extend_from_slice(&raw_value.as_bytes());
+
+    expected_map
+        .push_key(key.as_bytes(), &expected_value)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_map: expected_map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_push_header_wrong_key() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let wrong_key = "this is the WRONG key!";
+    let raw_value = "this is the value";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    stack.push_str(wrong_key);
+    stack.push_str(raw_value);
+    stack.push_u32(abi_data);
+
+    let mut expected_value = vec![];
+    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
+    expected_value.extend_from_slice(&raw_value.as_bytes());
+
+    expected_map
+        .push_key(key.as_bytes(), &expected_value)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_map: expected_map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_push_header_wrong_value() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let wrong_raw_value = "this is the WRONG value!";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    stack.push_str(key);
+    stack.push_str(wrong_raw_value);
+    stack.push_u32(abi_data);
+
+    let mut expected_value = vec![];
+    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
+    expected_value.extend_from_slice(&raw_value.as_bytes());
+
+    expected_map
+        .push_key(key.as_bytes(), &expected_value)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_map: expected_map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_push_header_wrong_size() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let raw_value = "this is the value";
+    let wrong_abi_data = HEADER_SIZE_2 as u32;
+
+    stack.push_str(key);
+    stack.push_str(raw_value);
+    stack.push_u32(wrong_abi_data);
+
+    let mut expected_value = vec![];
+    expected_value.extend_from_slice(&[HEADER_SIZE_1]);
+    expected_value.extend_from_slice(&raw_value.as_bytes());
+
+    expected_map
+        .push_key(key.as_bytes(), &expected_value)
+        .unwrap();
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_map: expected_map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}

--- a/tests/test_comap_abi/test_subsetting.rs
+++ b/tests/test_comap_abi/test_subsetting.rs
@@ -1,0 +1,108 @@
+use neutron_host::comap_abi_decoder::*;
+use neutron_host::element_interfaces::debug_data::*;
+use neutron_host::harness::*;
+use neutron_host::interface::*;
+
+const DIR_NAME: &'static str = "test_comap_abi";
+
+const CONTRACT_DIR_NAME: &'static str = "contract_subsetting";
+
+#[test]
+fn test_comap_peek_header_subsets() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let value_subset_1 = "<value part 1!>";
+    let value_subset_2 = "<value part 2!>";
+    let value_subset_3 = "<value part 3!>";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    // Construct a single String from the subsets
+    let mut value = String::from(value_subset_1);
+    value.push_str(value_subset_2);
+    value.push_str(value_subset_3);
+
+    // This will be used by contract to peek the comap value (one push for each subset, since a peek consumes the key it uses)
+    stack.push_str(key);
+    stack.push_str(key);
+    stack.push_str(key);
+
+    map.push_key_abi(key.as_bytes(), value.as_bytes(), abi_data)
+        .unwrap();
+
+    // We expect the contract to split the comap value into the subsets
+    expected_stack.push_str(value_subset_1, "value_subset_1");
+    expected_stack.push_u32(abi_data, "abi_data");
+    expected_stack.push_str(value_subset_2, "value_subset_2");
+    expected_stack.push_u32(abi_data, "abi_data");
+    expected_stack.push_str(value_subset_3, "value_subset_3");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}
+
+#[test]
+#[should_panic]
+fn negtest_comap_peek_header_subsets_wrong_value() {
+    let mut stack = DebugCoStack::default();
+    let mut expected_stack = WrappedDebugCoStack::default();
+    let mut map = DebugCoMap::default();
+
+    let key = "this is the key";
+    let value_subset_1 = "<value part 1!>";
+    let value_subset_2 = "<value part 2!>";
+    let value_subset_3 = "<value part 3!>";
+    let wrong_value_subset = "<WRONG subset!>";
+    let abi_data = HEADER_SIZE_1 as u32;
+
+    // Construct a single String from the subsets
+    let mut value = String::from(value_subset_1);
+    value.push_str(wrong_value_subset);
+    value.push_str(value_subset_3);
+
+    // This will be used by contract to peek the comap value (one push for each subset, since a peek consumes the key it uses)
+    stack.push_str(key);
+    stack.push_str(key);
+    stack.push_str(key);
+
+    map.push_key_abi(key.as_bytes(), value.as_bytes(), abi_data)
+        .unwrap();
+
+    // We expect the contract to split the comap value into the subsets
+    expected_stack.push_str(value_subset_1, "value_subset_1");
+    expected_stack.push_u32(abi_data, "abi_data");
+    expected_stack.push_str(value_subset_2, "value_subset_2");
+    expected_stack.push_u32(abi_data, "abi_data");
+    expected_stack.push_str(value_subset_3, "value_subset_3");
+    expected_stack.push_u32(abi_data, "abi_data");
+
+    let mut harness = TestHarness::default();
+    harness.debugdata = DebugDataInjector {
+        injected_input_stack: stack,
+        expected_output_stack: expected_stack,
+        injected_result_map: map,
+        ..DebugDataInjector::default()
+    };
+
+    let context = ExecutionContext::create_default_random_context();
+    harness.execute_debug_path_binary_using_default_callsystem(
+        DIR_NAME,
+        CONTRACT_DIR_NAME,
+        context,
+    );
+}


### PR DESCRIPTION
NOTE: This PR depends on a PR to neutron-star-rt: https://github.com/earlgreytech/neutron-star-rt/pull/2

Implement ABI-type comap ops to the hypervisor, tests for the new content, and some minor tinkering. 

It's pretty likely that the ABI coding functionality will be entirely migrated to neutron-common eventually, but it can reside here for now. 